### PR TITLE
Fix saving when working without passwords

### DIFF
--- a/PHP.php
+++ b/PHP.php
@@ -201,7 +201,7 @@
 		doLogs( 'save' );
 		$content = doControlPage( $_POST['content'] );
 		// save button is disabled if user is not logged, it should be test here too
-		if (!preg_match('/^(°|;|_|\{|\/)/', $content)) {
+		if (WITH_PASSWORDS && !preg_match('/^(°|;|_|\{|\/)/', $content)) {
 			header( "location: ?view=$page" );
 			return;
 		}


### PR DESCRIPTION
When WITH_PASSWORDS is set to false it was not possible to save the page as noone is logged in
